### PR TITLE
Optionally disable usage of wpiHalJNI

### DIFF
--- a/Pathfinding/build.gradle
+++ b/Pathfinding/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'java-library'
-    id "edu.wpi.first.GradleRIO" version "2024.2.1"
-    // id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id "edu.wpi.first.GradleRIO" version "2024.3.1"
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'maven-publish'
 }
 
 group 'me.nabdev.pathfinding'
-version '0.12.0'
+version '0.12.0-SNAPSHOT-WITHJNI2'
 
 java {
     withSourcesJar()
@@ -23,6 +23,11 @@ repositories {
 dependencies {
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
+
+
+    nativeRelease wpi.java.deps.wpilibJniRelease(wpi.platforms.desktop)
+    nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
+    simulationRelease wpi.sim.enableRelease()
 
     implementation 'org.json:json:20231013' 
 }

--- a/Pathfinding/build.gradle
+++ b/Pathfinding/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'me.nabdev.pathfinding'
-version '0.12.1'
+version '0.12.2'
 
 java {
     withSourcesJar()

--- a/Pathfinding/build.gradle
+++ b/Pathfinding/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'me.nabdev.pathfinding'
-version '0.12.0-SNAPSHOT-WITHJNI2'
+version '0.12.1'
 
 java {
     withSourcesJar()
@@ -23,11 +23,6 @@ repositories {
 dependencies {
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
-
-
-    nativeRelease wpi.java.deps.wpilibJniRelease(wpi.platforms.desktop)
-    nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
-    simulationRelease wpi.sim.enableRelease()
 
     implementation 'org.json:json:20231013' 
 }

--- a/Pathfinding/src/main/java/me/nabdev/pathfinding/Pathfinder.java
+++ b/Pathfinding/src/main/java/me/nabdev/pathfinding/Pathfinder.java
@@ -9,6 +9,7 @@ import me.nabdev.pathfinding.structures.Map;
 import me.nabdev.pathfinding.structures.Obstacle;
 import me.nabdev.pathfinding.structures.Path;
 import me.nabdev.pathfinding.structures.Vertex;
+import me.nabdev.pathfinding.utilities.DriverStationWrapper;
 import me.nabdev.pathfinding.utilities.FieldLoader.FieldData;
 import me.nabdev.pathfinding.utilities.FieldLoader.ObstacleData;
 
@@ -18,7 +19,6 @@ import java.util.Optional;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
@@ -79,9 +79,9 @@ public class Pathfinder {
      */
     private SearchAlgorithmType searchAlgorithmType;
 
-    private double lastMatchTime = DriverStation.getMatchTime();
-    private Optional<Alliance> lastAlliance = DriverStation.getAlliance();
-    private boolean lastIsAuto = DriverStation.isAutonomous();
+    private double lastMatchTime = DriverStationWrapper.getMatchTime();
+    private Optional<Alliance> lastAlliance = DriverStationWrapper.getAlliance();
+    private boolean lastIsAuto = DriverStationWrapper.isAutonomous();
     // Every obstacle vertex (ORDER IS IMPORTANT)
     ArrayList<Vertex> obstacleVertices = new ArrayList<>();
     ArrayList<Vertex> uninflatedObstacleVertices = new ArrayList<>();
@@ -162,16 +162,16 @@ public class Pathfinder {
      */
     public void periodic() {
         boolean shouldInvalidate = false;
-        if (DriverStation.getMatchTime() < endgameTime && !(lastMatchTime < endgameTime)) {
+        if (DriverStationWrapper.getMatchTime() < endgameTime && !(lastMatchTime < endgameTime)) {
             shouldInvalidate = true;
         }
-        lastMatchTime = DriverStation.getMatchTime();
-        Optional<Alliance> alliance = DriverStation.getAlliance();
+        lastMatchTime = DriverStationWrapper.getMatchTime();
+        Optional<Alliance> alliance = DriverStationWrapper.getAlliance();
         if (!alliance.equals(lastAlliance)) {
             lastAlliance = alliance;
             shouldInvalidate = true;
         }
-        boolean isAuto = DriverStation.isAutonomous();
+        boolean isAuto = DriverStationWrapper.isAutonomous();
         if (isAuto != lastIsAuto) {
             lastIsAuto = isAuto;
             shouldInvalidate = true;

--- a/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveAutoModifier.java
+++ b/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveAutoModifier.java
@@ -1,6 +1,6 @@
 package me.nabdev.pathfinding.modifiers;
 
-import edu.wpi.first.wpilibj.DriverStation;
+import me.nabdev.pathfinding.utilities.DriverStationWrapper;
 
 /**
  * A modifier that keeps the obstacle active during the autonomous period
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj.DriverStation;
 public class ActiveAutoModifier extends ObstacleModifier {
     @Override
     public boolean isActive() {
-        return DriverStation.isAutonomous();
+        return DriverStationWrapper.isAutonomous();
     }
 
     @Override

--- a/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveEndgameModifier.java
+++ b/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveEndgameModifier.java
@@ -1,7 +1,7 @@
 package me.nabdev.pathfinding.modifiers;
 
-import edu.wpi.first.wpilibj.DriverStation;
 import me.nabdev.pathfinding.Pathfinder;
+import me.nabdev.pathfinding.utilities.DriverStationWrapper;
 
 /**
  * A modifier that keeps the obstacle active during the endgame period
@@ -10,8 +10,8 @@ public class ActiveEndgameModifier extends ObstacleModifier {
 
     @Override
     public boolean isActive() {
-        if (DriverStation.isTeleop()) {
-            double matchTime = DriverStation.getMatchTime();
+        if (DriverStationWrapper.isTeleop()) {
+            double matchTime = DriverStationWrapper.getMatchTime();
             if (matchTime <= Pathfinder.getEndgameTime()) {
                 return true;
             }

--- a/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveMyAllianceModifier.java
+++ b/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveMyAllianceModifier.java
@@ -2,8 +2,8 @@ package me.nabdev.pathfinding.modifiers;
 
 import java.util.Optional;
 
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import me.nabdev.pathfinding.utilities.DriverStationWrapper;
 
 /**
  * A modifier that keeps the obstacle active if it is the same alliance as the
@@ -23,10 +23,10 @@ public class ActiveMyAllianceModifier extends ObstacleModifier {
 
     @Override
     public boolean isActive() {
-        Optional<Alliance> alliance = DriverStation.getAlliance();
+        Optional<Alliance> alliance = DriverStationWrapper.getAlliance();
         if (!alliance.isPresent())
             return false;
-        if (alliance.get() == DriverStation.Alliance.Blue) {
+        if (alliance.get() == Alliance.Blue) {
             return myCollection.hasModifier(ObstacleModifierTypes.BLUE_ALLIANCE);
         } else {
             return myCollection.hasModifier(ObstacleModifierTypes.RED_ALLIANCE);

--- a/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveOtherAllianceModifier.java
+++ b/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveOtherAllianceModifier.java
@@ -2,8 +2,8 @@ package me.nabdev.pathfinding.modifiers;
 
 import java.util.Optional;
 
-import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import me.nabdev.pathfinding.utilities.DriverStationWrapper;
 
 /**
  * A modifier that keeps the obstacle active if it is not the same alliance as
@@ -23,10 +23,10 @@ public class ActiveOtherAllianceModifier extends ObstacleModifier {
 
     @Override
     public boolean isActive() {
-        Optional<Alliance> alliance = DriverStation.getAlliance();
+        Optional<Alliance> alliance = DriverStationWrapper.getAlliance();
         if (!alliance.isPresent())
             return false;
-        if (alliance.get() == DriverStation.Alliance.Blue) {
+        if (alliance.get() == Alliance.Blue) {
             return myCollection.hasModifier(ObstacleModifierTypes.RED_ALLIANCE);
         } else {
             return myCollection.hasModifier(ObstacleModifierTypes.BLUE_ALLIANCE);

--- a/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveTeleModifier.java
+++ b/Pathfinding/src/main/java/me/nabdev/pathfinding/modifiers/ActiveTeleModifier.java
@@ -1,7 +1,7 @@
 package me.nabdev.pathfinding.modifiers;
 
-import edu.wpi.first.wpilibj.DriverStation;
 import me.nabdev.pathfinding.Pathfinder;
+import me.nabdev.pathfinding.utilities.DriverStationWrapper;
 
 /**
  * A modifier that keeps the obstacle active during the teleop period, not
@@ -10,8 +10,8 @@ import me.nabdev.pathfinding.Pathfinder;
 public class ActiveTeleModifier extends ObstacleModifier {
     @Override
     public boolean isActive() {
-        if (DriverStation.isTeleop()) {
-            double matchTime = DriverStation.getMatchTime();
+        if (DriverStationWrapper.isTeleop()) {
+            double matchTime = DriverStationWrapper.getMatchTime();
             if (matchTime <= Pathfinder.getEndgameTime()) {
                 return false;
             }

--- a/Pathfinding/src/main/java/me/nabdev/pathfinding/utilities/DriverStationWrapper.java
+++ b/Pathfinding/src/main/java/me/nabdev/pathfinding/utilities/DriverStationWrapper.java
@@ -5,12 +5,23 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 
 import java.util.Optional;
 
+/**
+ * A wrapper class for the DriverStation class that allows for the use of the
+ * DriverStation class in an environment where wpiHalJNI is unavailable (I.E.
+ * OxplorerGUI). Returns default values if -Dnohaljni=true is given to the JVM.
+ */
 public class DriverStationWrapper {
     private static boolean canUseJni;
     static {
         canUseJni = !Boolean.getBoolean("nohaljni");
     }
 
+    /**
+     * Returns whether the Driver Station is currently enabled. False if HALJNI is
+     * disabled.
+     * 
+     * @return true if the Driver Station is currently enabled, false otherwise
+     */
     public static boolean isAutonomous() {
         if (canUseJni) {
             return DriverStation.isAutonomous();
@@ -19,6 +30,12 @@ public class DriverStationWrapper {
         }
     }
 
+    /**
+     * Returns whether the Driver Station is currently enabled. True if HALJNI is
+     * disabled.
+     * 
+     * @return true if the Driver Station is currently enabled, false otherwise
+     */
     public static boolean isTeleop() {
         if (canUseJni) {
             return DriverStation.isTeleop();
@@ -27,6 +44,12 @@ public class DriverStationWrapper {
         }
     }
 
+    /**
+     * Returns whether the Driver Station is currently enabled. False if HALJNI is
+     * disabled.
+     * 
+     * @return true if the Driver Station is currently enabled, false otherwise
+     */
     public static double getMatchTime() {
         if (canUseJni) {
             return DriverStation.getMatchTime();
@@ -35,6 +58,12 @@ public class DriverStationWrapper {
         }
     }
 
+    /**
+     * Returns the alliance that the driver station is on. If HALJNI is disabled,
+     * returns an empty Optional.
+     * 
+     * @return the alliance that the driver station is on
+     */
     public static Optional<Alliance> getAlliance() {
         if (canUseJni) {
             return DriverStation.getAlliance();

--- a/Pathfinding/src/main/java/me/nabdev/pathfinding/utilities/DriverStationWrapper.java
+++ b/Pathfinding/src/main/java/me/nabdev/pathfinding/utilities/DriverStationWrapper.java
@@ -1,0 +1,45 @@
+package me.nabdev.pathfinding.utilities;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
+
+import java.util.Optional;
+
+public class DriverStationWrapper {
+    private static boolean canUseJni;
+    static {
+        canUseJni = !Boolean.getBoolean("nohaljni");
+    }
+
+    public static boolean isAutonomous() {
+        if (canUseJni) {
+            return DriverStation.isAutonomous();
+        } else {
+            return false;
+        }
+    }
+
+    public static boolean isTeleop() {
+        if (canUseJni) {
+            return DriverStation.isTeleop();
+        } else {
+            return true;
+        }
+    }
+
+    public static double getMatchTime() {
+        if (canUseJni) {
+            return DriverStation.getMatchTime();
+        } else {
+            return 0;
+        }
+    }
+
+    public static Optional<Alliance> getAlliance() {
+        if (canUseJni) {
+            return DriverStation.getAlliance();
+        } else {
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
This is neccessary for using Oxplorer in non-rio and non-simulation environments, as the DriverStation class relies on the haljni which cannot be directly bundled with the oxplorer jar. This PR will check for `-Dnohaljni=true` as a JVM option, and if it is present, it will return default values instead of using the DriverStation class.

This change was made to facilitate the OxplorerGUI.